### PR TITLE
Added missing key to test_make_index()

### DIFF
--- a/oevelser/1-setup/test_exercise1.py
+++ b/oevelser/1-setup/test_exercise1.py
@@ -16,7 +16,8 @@ class TestExercise1(unittest.TestCase):
             'the' : 3,
             'quick' : 1,
             'jumps' : 1,
-            'wall' : 1
+            'wall' : 1,
+            'over' : 1
         }
         self.assertEqual(exercise1.make_index(input), expected)
     


### PR DESCRIPTION
Input matcher ikke med forventet output fordi 'over' ikke er tatt med i expected dict. Fører til at testen alltid feiler. 