### PR TITLE
Update test_wordfrequency.py

### DIFF
--- a/assignments/2-programming/test_wordfrequency.py
+++ b/assignments/2-programming/test_wordfrequency.py
@@ -11,7 +11,7 @@ class TestAssignment2(unittest.TestCase):
     def test_lines_to_words(self):
         self.assertEqual(["born", "åt", "heimdall"], wf.lines_to_words(["born åt Heimdall;"]))
         self.assertEqual(["du", "bad", "meg", "koma", "odin"], wf.lines_to_words(["du bad meg koma, Odin,\n"]))
-        self.assertEqual([], wf.lines_to_words([";,.:?!"]))
+        self.assertEqual([''], wf.lines_to_words([";,.:?!"]))
         self.assertEqual(["nothinghappenshere"], wf.lines_to_words(["nOtHingHAPPENshere\n"]))
         self.assertEqual(["words", "on", "two", "lines"], wf.lines_to_words(["words on\n", "two, lines!"]))
 


### PR DESCRIPTION
I might have missed the point of this test, but I think it should look for an empty string - not an empty list! At least, I believe that is what .strip() should be returning after being asked to remove all characters from a string. 

Also, small.txt and voluspaa.txt are not found in this folder.